### PR TITLE
Fix macOS transparency and dragging interaction

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
+tauri = { version = "2", features = ["macos-private-api", "tray-icon", "image-png"] }
 tauri-plugin-single-instance = "2"
 axum = { version = "0.7", features = ["json"] }
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,7 +102,7 @@ fn drag_move(app: AppHandle, drag: tauri::State<SharedDrag>, x: f64, y: f64) {
     }
     // Construct updated bounds from the new position + known size (avoid second IPC query)
     let updated = windows::WindowBounds { x: new_x, y: new_y, width: pet_w, height: pet_h };
-    windows::sync_hit_window(&app, &updated, &windows::HitBox::DEFAULT);
+    windows::sync_hit_window(&app, &updated, &windows::HitBox::INTERACTIVE);
 }
 
 #[tauri::command]
@@ -353,7 +353,7 @@ fn is_left_mini(app: &AppHandle) -> bool {
 
 pub(crate) fn sync_hit(app: &AppHandle) {
     if let Some(bounds) = windows::get_pet_bounds(app) {
-        windows::sync_hit_window(app, &bounds, &windows::HitBox::DEFAULT);
+        windows::sync_hit_window(app, &bounds, &windows::HitBox::INTERACTIVE);
     }
 }
 
@@ -526,7 +526,7 @@ fn setup_hit_window(app: &AppHandle) {
         let _ = hit.set_background_color(Some(Color(0, 0, 0, 0)));
     }
     if let Some(bounds) = windows::get_pet_bounds(app) {
-        windows::sync_hit_window(app, &bounds, &windows::HitBox::DEFAULT);
+        windows::sync_hit_window(app, &bounds, &windows::HitBox::INTERACTIVE);
         windows::show_hit_window(app);
         println!("Clyde: hit window synced to pet bounds");
     } else {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -65,7 +65,7 @@ fn apply_size(app: &AppHandle, size_str: &str) {
         let (w, h) = prefs::size_to_pixels(size_str);
         let _ = pet.set_size(tauri::PhysicalSize::new(w, h));
         if let Some(bounds) = windows::get_pet_bounds(app) {
-            windows::sync_hit_window(app, &bounds, &windows::HitBox::DEFAULT);
+            windows::sync_hit_window(app, &bounds, &windows::HitBox::INTERACTIVE);
         }
     }
     if let Some(prefs_state) = app.try_state::<SharedPrefs>() {

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -31,6 +31,9 @@ pub struct HitRect {
 
 impl HitBox {
     pub const DEFAULT:  HitBox = HitBox { x: -1, y: 5,  w: 17, h: 12 };
+    // A generous interaction area so dragging works across the full pet,
+    // not just the sprite's narrow torso hotspot.
+    pub const INTERACTIVE: HitBox = HitBox { x: -10, y: -16, w: 35, h: 35 };
     #[allow(dead_code)]
     pub const SLEEPING: HitBox = HitBox { x: -2, y: 9,  w: 19, h: 7  };
     #[allow(dead_code)]
@@ -126,5 +129,15 @@ mod tests {
             (wide_rect.right - wide_rect.left) > (default_rect.right - default_rect.left),
             "WIDE hitbox should produce wider rect"
         );
+    }
+
+    #[test]
+    fn test_interactive_hitbox_covers_most_of_pet_window() {
+        let bounds = WindowBounds { x: 0, y: 0, width: 200, height: 200 };
+        let rect = compute_hit_rect(&bounds, &HitBox::INTERACTIVE);
+        assert!(rect.left <= 5.0, "interactive hit area should start near left edge");
+        assert!(rect.top <= 5.0, "interactive hit area should start near top edge");
+        assert!(rect.right >= 195.0, "interactive hit area should reach near right edge");
+        assert!(rect.bottom >= 195.0, "interactive hit area should reach near bottom edge");
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,6 +9,7 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "label": "pet",

--- a/src/windows/hit/index.html
+++ b/src/windows/hit/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <style>
     * { margin: 0; padding: 0; }
-    html, body, #app { width: 100%; height: 100%; background: transparent; overflow: hidden; }
+    html, body, #app { width: 100%; height: 100%; background: rgba(0, 0, 0, 0.01); overflow: hidden; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- enable the Tauri macOS private API so transparent windows actually render as transparent on macOS
- expand the interactive hit area used for dragging so Clyde can be dragged reliably across the pet window
- give the hit window a near-transparent background so it still receives pointer events on macOS

## Testing
- cargo test --manifest-path src-tauri/Cargo.toml windows::