### PR TITLE
fix: keep hit window aligned on startup and resize

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -450,9 +450,13 @@ fn trigger_wake(app: AppHandle, state: tauri::State<'_, SharedState>, abort_hand
 #[tauri::command]
 fn set_window_size(app: AppHandle, size: String, prefs: tauri::State<SharedPrefs>) {
     if let Some(pet) = app.get_webview_window("pet") {
+        let current_bounds = windows::get_pet_bounds(&app);
         let (w, h) = prefs::size_to_pixels(&size);
         let _ = pet.set_size(tauri::PhysicalSize::new(w, h));
-        sync_hit(&app);
+        if let Some(current) = current_bounds {
+            let updated = windows::resized_pet_bounds(&current, w, h);
+            windows::sync_hit_window(&app, &updated, &windows::HitBox::DEFAULT);
+        }
         let mut p = prefs.lock_or_recover();
         p.size = size;
         prefs::save(&app, &p);
@@ -521,17 +525,14 @@ fn setup_pet_window(app: &AppHandle, prefs: &prefs::Prefs) {
     pet.open_devtools();
 }
 
-fn setup_hit_window(app: &AppHandle) {
+fn setup_hit_window(app: &AppHandle, prefs: &prefs::Prefs) {
     if let Some(hit) = app.get_webview_window("hit") {
         let _ = hit.set_background_color(Some(Color(0, 0, 0, 0)));
     }
-    if let Some(bounds) = windows::get_pet_bounds(app) {
-        windows::sync_hit_window(app, &bounds, &windows::HitBox::DEFAULT);
-        windows::show_hit_window(app);
-        println!("Clyde: hit window synced to pet bounds");
-    } else {
-        eprintln!("Clyde: could not get pet bounds for hit window sync");
-    }
+    let bounds = windows::startup_pet_bounds(prefs);
+    windows::sync_hit_window(app, &bounds, &windows::HitBox::DEFAULT);
+    windows::show_hit_window(app);
+    println!("Clyde: hit window synced to startup bounds");
 }
 
 fn setup_tray(app: &AppHandle, prefs: &prefs::Prefs, shared_tray: &tray::SharedTray) {
@@ -605,7 +606,7 @@ pub fn run() {
             *shared_prefs.lock_or_recover() = prefs.clone();
 
             setup_pet_window(app.handle(), &prefs);
-            setup_hit_window(app.handle());
+            setup_hit_window(app.handle(), &prefs);
             setup_tray(app.handle(), &prefs, &shared_tray);
 
             // Save position on close

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -62,10 +62,12 @@ pub fn rebuild_menu(app: &AppHandle, lang: &str) {
 pub fn apply_size_pub(app: &AppHandle, size_str: &str) { apply_size(app, size_str); }
 fn apply_size(app: &AppHandle, size_str: &str) {
     if let Some(pet) = app.get_webview_window("pet") {
+        let current_bounds = windows::get_pet_bounds(app);
         let (w, h) = prefs::size_to_pixels(size_str);
         let _ = pet.set_size(tauri::PhysicalSize::new(w, h));
-        if let Some(bounds) = windows::get_pet_bounds(app) {
-            windows::sync_hit_window(app, &bounds, &windows::HitBox::DEFAULT);
+        if let Some(current) = current_bounds {
+            let updated = windows::resized_pet_bounds(&current, w, h);
+            windows::sync_hit_window(app, &updated, &windows::HitBox::DEFAULT);
         }
     }
     if let Some(prefs_state) = app.try_state::<SharedPrefs>() {

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -91,6 +91,25 @@ pub fn get_pet_bounds(app: &AppHandle) -> Option<WindowBounds> {
     })
 }
 
+pub fn startup_pet_bounds(prefs: &crate::prefs::Prefs) -> WindowBounds {
+    let (width, height) = crate::prefs::size_to_pixels(&prefs.size);
+    WindowBounds {
+        x: prefs.x,
+        y: prefs.y,
+        width,
+        height,
+    }
+}
+
+pub fn resized_pet_bounds(current: &WindowBounds, width: u32, height: u32) -> WindowBounds {
+    WindowBounds {
+        x: current.x,
+        y: current.y,
+        width,
+        height,
+    }
+}
+
 pub fn show_hit_window(app: &AppHandle) {
     if let Some(w) = app.get_webview_window("hit") {
         let _ = w.show();
@@ -126,5 +145,30 @@ mod tests {
             (wide_rect.right - wide_rect.left) > (default_rect.right - default_rect.left),
             "WIDE hitbox should produce wider rect"
         );
+    }
+
+    #[test]
+    fn test_startup_bounds_use_stored_prefs_position_and_size() {
+        let prefs = crate::prefs::Prefs {
+            x: 100,
+            y: 100,
+            size: "L".into(),
+            ..Default::default()
+        };
+        let bounds = startup_pet_bounds(&prefs);
+        assert_eq!(bounds.x, 100);
+        assert_eq!(bounds.y, 100);
+        assert_eq!(bounds.width, 360);
+        assert_eq!(bounds.height, 360);
+    }
+
+    #[test]
+    fn test_resize_bounds_keep_position_and_apply_new_size() {
+        let current = WindowBounds { x: 320, y: 180, width: 200, height: 200 };
+        let resized = resized_pet_bounds(&current, 360, 360);
+        assert_eq!(resized.x, 320);
+        assert_eq!(resized.y, 180);
+        assert_eq!(resized.width, 360);
+        assert_eq!(resized.height, 360);
     }
 }


### PR DESCRIPTION
## Summary
- sync the hit window from persisted startup bounds instead of immediately re-reading window geometry
- keep the hit window aligned after S/M/L size changes by reusing the current position with the new known size
- add regression tests for startup bounds and resize bounds handling

## Test Plan
- [x] cargo test --manifest-path src-tauri/Cargo.toml
- [x] manually verify startup alignment
- [x] manually verify S / M / L switching keeps the hit window aligned